### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,14 +273,8 @@ To include the msvcr100.dll to improve the target os compatibility change the li
     
 # Use LOKI on Mac OS X
 
-- Download Yara sources from [here](https://github.com/plusvic/yara/releases/tag/v3.4.0)
-- Install openssl (brew install openssl, then sudo cp -r /usr/local/Cellar/openssl/1.0.2h_1/include /usr/local)
-- ./build.sh
-- sudo make install
-- Change to folder ```yara-python```
-- Run ```python setup.py install```
-- Also install the requirements, ```sudo pip install colorama``` gitpython, netaddr, pylzma etc...
-- Download and unpack https://github.com/Neo23x0/signature-base into Loki folder
+- ```brew install yara```
+- Also install the requirements: ```sudo pip install yara-python``` and colorama, gitpython, netaddr, pylzma, psutil
 - cd loki folder, sudo python loki.py -p /
 
 # Antivirus - False Positives


### PR DESCRIPTION
brew now has a fresh version of yara (currently 3.5), and pip has a fresh version of yara-python. I'm not very comfortable with the 'sudo pip install', but describing a clean python setup is out of scope here (pyenv is a nicer option).