### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you want to build it yourself:
 
 ### Linux or OS X
 
-- [yara](https://github.com/VirusTotal/yara/) : just use the latest release source code, compile and install it
+- [yara](https://github.com/VirusTotal/yara/) : just use the latest release source code, compile and install it (or install it via pip install yara-python)
 - Some Python packages: pip install psutil netaddr pylzma colorama
 
 ### Windows


### PR DESCRIPTION
Using libraries like the ones provided by the repos of Debian, or the old pip install yara will create errors while running loki. Using the libraries provided by the pip package "yara-python" is error-free.