### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ netaddr
 psutil
 pylzma
 yara-python
+colorama


### PR DESCRIPTION
requirements.txt is missing `colorama` this will cause `python loki.py` to throw an error when a run is attempted, adding this to the requirements.txt ensures this will be installed on a `pip install -r requirements.txt`