### PR TITLE
Add pycrypto module to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pylzma
 yara-python
 colorama
 rfc5424-logging-handler
+pycrypto


### PR DESCRIPTION
Hi,

When running Loki in an Alpine Linux 3.10 with Python 2.7, it complains about `ImportError: No module named Crypto.Cipher`, which is solved by `pip install pycrypto`.

Best regards.