### PR TITLE
Show error when downloading signatures instead of generic message

### DIFF
--- a/loki-upgrader.py
+++ b/loki-upgrader.py
@@ -45,7 +45,7 @@ class LOKIUpdater(object):
   
     UPDATE_URL_SIGS = [
         "https://github.com/Neo23x0/signature-base/archive/master.zip",
-        "https://github.com/reversinglabs/reversinglabs-yara-rules/archive/master.zip"
+        "https://github.com/reversinglabs/reversinglabs-yara-rules/archive/develop.zip"
     ]
     
     UPDATE_URL_LOKI = "https://api.github.com/repos/Neo23x0/Loki/releases/latest"
@@ -65,7 +65,8 @@ class LOKIUpdater(object):
                 except Exception as e:
                     if self.debug:
                         traceback.print_exc()
-                    self.logger.log("ERROR", "Upgrader", "Error downloading the signature database - %s" % e)
+                    self.logger.log("ERROR", "Upgrader", "Error downloading the signature database - "
+                                                         "check your Internet connection")
                     sys.exit(1)
 
                 # Preparations

--- a/loki-upgrader.py
+++ b/loki-upgrader.py
@@ -65,8 +65,7 @@ class LOKIUpdater(object):
                 except Exception as e:
                     if self.debug:
                         traceback.print_exc()
-                    self.logger.log("ERROR", "Upgrader", "Error downloading the signature database - "
-                                                         "check your Internet connection")
+                    self.logger.log("ERROR", "Upgrader", "Error downloading the signature database - %s" % e)
                     sys.exit(1)
 
                 # Preparations


### PR DESCRIPTION
I feel that "check your Internet connection" can be a misleading message in certain situations, e.g., when the remote file doesn't exist (404) or access is forbidden (403). Instead, I suggest to log the exact error from the exception.