### PR TITLE
docs: fix simple typo, excluces -> excludes

### DIFF
--- a/loki.py
+++ b/loki.py
@@ -104,7 +104,7 @@ class Loki(object):
     # Yara rule directories
     yara_rule_directories = []
 
-    # Excludes (list of regex that match within the whole path) (user-defined via excluces.cfg)
+    # Excludes (list of regex that match within the whole path) (user-defined via excludes.cfg)
     fullExcludes = []
     # Platform specific excludes (match the beginning of the full path) (not user-defined)
     startExcludes = []


### PR DESCRIPTION
There is a small typo in loki.py.

Should read `excludes` rather than `excluces`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md