### PR TITLE
move from py2 to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Download the latest version of LOKI from the [releases](https://github.com/Neo23
     2. Search the web for the filename
     3. Search the web for keywords from the rule name (e.g. EQUATIONGroupMalware_1 > search for "Equation Group")
     4. Search the web for the MD5 hash of the sample
-    5. Search in my [customer APT search engine](https://cse.google.com/cse/publicurl?cx=003248445720253387346:turlh5vi4xc) for file names or identifiers
+    5. Search in my [custom APT search engine](https://cse.google.com/cse/publicurl?cx=003248445720253387346:turlh5vi4xc) for file names or identifiers
   - Please report back false positives via the [Issues](https://github.com/Neo23x0/Loki/issues) section (mention the false positive indicator like a hash and/or filename and the rule name that triggered)
 
 ## Update

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -27,6 +27,7 @@ import time
 import threading
 import subprocess
 import signal
+import codecs
 
 # Helper Functions -------------------------------------------------------------
 
@@ -80,9 +81,12 @@ def removeNonAsciiDrop(string):
     #print "CON: ", string
     try:
         # Generate a new string without disturbing characters
+        # convert string to str in case it's bytes (for python3)
+        # TODO: check if that gives the same results as in py2
+        string = string.decode("utf-8", errors='ignore')
         nonascii = "".join(i for i in string if ord(i)<127 and ord(i)>31)
 
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         pass
     #print "NON: ", nonascii
@@ -93,7 +97,7 @@ def getPlatformFull():
     type_info = ""
     try:
         type_info = "%s PROC: %s ARCH: %s" % ( " ".join(platform.win32_ver()), platform.processor(), " ".join(platform.architecture()))
-    except Exception, e:
+    except Exception as e:
         type_info = " ".join(platform.win32_ver())
     return type_info
 
@@ -105,7 +109,7 @@ def setNice(logger):
         logger.log("INFO", "Init", "Setting LOKI process with PID: %s to priority IDLE" % pid)
         p.nice(psutil.IDLE_PRIORITY_CLASS)
         return 1
-    except Exception, e:
+    except Exception as e:
         if logger.debug:
             traceback.print_exc()
         logger.log("ERROR", "Init", "Error setting nice value of THOR process")
@@ -152,7 +156,9 @@ def decompressSWFData(in_data):
 
 
 def removeBinaryZero(string):
-    return re.sub(r'\x00','',string)
+    #return re.sub(r'\x00','',string)
+    # py2 => py3:
+    return string.replace(b'\x00',b'')
 
 
 def printProgress(i):
@@ -210,9 +216,9 @@ def get_file_type(filePath, filetype_sigs, max_filetype_magics, logger):
         res_full = open(filePath, 'rb', os.O_RDONLY).read(max_filetype_magics)
         # Checking sigs
         for sig in filetype_sigs:
-            bytes_to_read = len(str(sig)) / 2
+            bytes_to_read = int(len(str(sig)) / 2) 
             res = res_full[:bytes_to_read]
-            if res == sig.decode('hex'):
+            if res == bytes.fromhex(sig):
                 return filetype_sigs[sig]
         return "UNKNOWN"
     except Exception as e:
@@ -224,17 +230,25 @@ def get_file_type(filePath, filetype_sigs, max_filetype_magics, logger):
 def removeNonAscii(string, stripit=False):
     nonascii = "error"
 
+
     try:
         try:
             # Handle according to the type
-            if isinstance(string, unicode) and not stripit:
-                nonascii = string.encode('unicode-escape')
-            elif isinstance(string, str) and not stripit:
+            # py2 => py3
+            #if isinstance(string, unicode) and not stripit:
+            if isinstance(string, str) and not stripit:
+                # hmmm, the original version didn't do what the function name says: "remove non ascii":
+                #nonascii = string.encode('unicode-escape')
+                # ... so this should be ok? to avoid the problem, that any kind of python3 encode messes up the regexes, e.g. \. => \\.
+                nonascii = string
+            # py2 => py3
+            #elif isinstance(string, str) and not stripit:
+            elif isinstance(string, bytes) and not stripit:
                 nonascii = string.decode('utf-8', 'replace').encode('unicode-escape')
             else:
                 try:
                     nonascii = string.encode('raw_unicode_escape')
-                except Exception, e:
+                except Exception as e:
                     nonascii = str("%s" % string)
 
         except Exception as e:

--- a/lib/pesieve.py
+++ b/lib/pesieve.py
@@ -63,7 +63,7 @@ class PESieve(object):
             results_raw = json.loads(output)
             results = results_raw["scanned"]["modified"]
             if self.logger.debug:
-                print results
+                print(results)
         except ValueError as v:
             self.logger.log("DEBUG", "PESieve", "Couldn't parse the JSON output.")
         except Exception as e:

--- a/lib/pluginframework.py
+++ b/lib/pluginframework.py
@@ -64,7 +64,11 @@ def LoadPlugins(dGlobals, dLocals):
                 if file.endswith('.py') and file != FILENAME_LOKI_INIT:
                     pluginFile = os.path.join(root, file)
                     try:
-                        execfile(pluginFile, dGlobals, dLocals)
+                        #execfile(pluginFile, dGlobals, dLocals)
+                        # python3 way:
+                        with open(pluginFile) as f:
+                            code = compile(f.read(), pluginFile, 'exec')
+                            exec(code, dGlobals, dLocals)
                         logger.log('NOTICE', 'Init', 'Loaded plugin %s' % pluginFile)
                     except:
                         logger.log('ERROR', 'Init', 'Failed to load PLUGIN: %s ERROR: %s' % (pluginFile, sys.exc_info()[1]))

--- a/lib/privrules.py
+++ b/lib/privrules.py
@@ -37,7 +37,7 @@ def read_rules_from_dir(directory):
                 'md5': dummy,
             })
             print("Adding rule file %s ..." % rulefile)
-        except Exception, e:
+        except Exception as e:
             print("Error compiling rule %s (%s)" % (rulefile, e))
             sys.exit(-1)
 
@@ -54,8 +54,8 @@ def read_rules_from_dir(directory):
             'filetype': dummy,
             'md5': dummy,
         })
-    except Exception, e:
-        print "Error compiling composed ruleset (%s)" % e
+    except Exception as e:
+        print ("Error compiling composed ruleset (%s)" % e)
         sys.exit(-1)
 
     return compiled_rules


### PR DESCRIPTION
works perfectly for yara and filename iocs, not a byte difference in the logs on 1600 hits. but I didn't have test cases for wmi and process scanning.

it's not backwards compatible to python2 because it was awkward at some places with the conversions between old unicode, bytes, str, ... and py2 is end of life anyway.