### PR TITLE
Python 3 compatibility: Lint code with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 3.8
 cache: pip
 install:
-  - pip install colorama flake8 netaddr psutil rfc5424-logging-handler yara-python  
+  - pip install colorama flake8 future netaddr psutil rfc5424-logging-handler yara-python  
 
 script:
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ python:
   - 3.8
 cache: pip
 install:
-  - pip install yara-python
-  - pip install psutil
-  - pip install colorama
-  - pip install netaddr
-  - pip install rfc5424-logging-handler
+  - pip install colorama flake8 netaddr psutil rfc5424-logging-handler yara-python  
 
 script:
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - python ./loki.py --noprocs --noindicator --dontwait --debug -p ./test
   - python ./loki.py --noprocs --noindicator --dontwait --debug --intense -p ./test
   - python ./loki.py --noprocs --noindicator --dontwait --debug --csv -p ./test


### PR DESCRIPTION
`pip` now has a real dependency resolver so give it all dependencies in a single command.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.