### PR TITLE
Resolve undefined names: os_platform and wmi

### DIFF
--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -8,9 +8,16 @@ Author: @DidierStevens
 """
 
 import hashlib
+import sys
 
 def ScanWMI():
-    if os_platform == "windows":
+    if sys.platform in ("win32", "cygwin"):
+        try:
+            import wmi
+        except ImportError as e:
+            wmi = None
+            logger.log("CRITICAL", "WMIScan", "Unable to import wmi")
+            print("Unable to import wmi")
         oWMI = wmi.WMI(namespace=r'root\subscription')
 
         knownHashes = ['159e2bcde798cf5fbb290f90a7ccc1a6', '20d385446e60cf9134792d5b145c54bb', '65c80cb7a9094b32c3f9982887b9862a', '6ddb270d17551138747ad7c1bc3db9b3', 'de5b1c4f59c4463f8e9b70cbe1156976']


### PR DESCRIPTION
$ `flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics`
```
./plugins/loki-plugin-wmi.py:13:8: F821 undefined name 'os_platform'
    if os_platform == "windows":
       ^
/plugins/loki-plugin-wmi.py:14:16: F821 undefined name 'wmi'
        oWMI = wmi.WMI(namespace=r'root\subscription')
               ^
```
https://docs.python.org/3/library/sys.html#sys.platform do we want to support `cygwin`?

A short form of the logic at https://github.com/Neo23x0/Loki/blob/master/loki.py#L36-L63

https://pypi.org/project/WMI