### PR TITLE
Fix undefined name: logging

### DIFF
--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -69,4 +69,5 @@ def ScanWMI():
         for ActiveScriptEventConsumer in lActiveScriptEventConsumer:
             logger.log("INFO", "WMIScan", repr(str(ActiveScriptEventConsumer)))
 
-LokiRegisterPlugin("PluginWMI", ScanWMI, 1)
+
+LokiRegisterPlugin("PluginWMI", ScanWMI, 1)  # noqa: F821 undefined name 'LokiRegisterPlugin'

--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -11,7 +11,7 @@ import hashlib
 import sys
 
 def ScanWMI():
-    global logger  # logger is defined on loki.py.__main__
+    global logger  # logger is defined in loki.py.__main__
 
     if sys.platform in ("win32", "cygwin"):
         try:

--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -11,6 +11,8 @@ import hashlib
 import sys
 
 def ScanWMI():
+    global logger  # logger is defined on loki.py.__main__
+
     if sys.platform in ("win32", "cygwin"):
         try:
             import wmi


### PR DESCRIPTION
`global logger`  # logger is defined in `loki.py.__main__`

https://github.com/Neo23x0/Loki/blob/master/loki.py#L1495-L1496

https://docs.python.org/3/reference/simple_stmts.html#global

$ `flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics`
```
./plugins/loki-plugin-wmi.py:19:13: F821 undefined name 'logger'
            logger.log("CRITICAL", "WMIScan", "Unable to import wmi")
            ^
./plugins/loki-plugin-wmi.py:32:13: F821 undefined name 'logger'
            logger.log("WARNING", "WMIScan", 'Error retrieving __eventFilter')
            ^
./plugins/loki-plugin-wmi.py:36:13: F821 undefined name 'logger'
            logger.log("WARNING", "WMIScan", 'Error retrieving __FilterToConsumerBinding')
            ^
./plugins/loki-plugin-wmi.py:40:13: F821 undefined name 'logger'
            logger.log("WARNING", "WMIScan", 'Error retrieving CommandLineEventConsumer')
            ^
./plugins/loki-plugin-wmi.py:44:13: F821 undefined name 'logger'
            logger.log("WARNING", "WMIScan", 'Error retrieving ActiveScriptEventConsumer')
            ^
./plugins/loki-plugin-wmi.py:50:21: F821 undefined name 'logger'
                    logger.log("WARNING", "WMIScan", 'CLASS: __eventFilter MD5: %s NAME: %s QUERY: %s' % (hashEntry, eventFilter.wmi_property('Name').value, eventFilter.wmi_property('Query').value))
                    ^
./plugins/loki-plugin-wmi.py:52:17: F821 undefined name 'logger'
                logger.log("INFO", "WMIScan", repr(str(eventFilter)))
                ^
./plugins/loki-plugin-wmi.py:57:21: F821 undefined name 'logger'
                    logger.log("WARNING", "WMIScan", 'CLASS: __FilterToConsumerBinding MD5: %s CONSUMER: %s FILTER: %s' % (hashEntry, FilterToConsumerBinding.wmi_property('Consumer').value, FilterToConsumerBinding.wmi_property('Filter').value))
                    ^
./plugins/loki-plugin-wmi.py:59:17: F821 undefined name 'logger'
                logger.log("INFO", "WMIScan", repr(str(FilterToConsumerBinding)))
                ^
./plugins/loki-plugin-wmi.py:64:21: F821 undefined name 'logger'
                    logger.log("WARNING", "WMIScan", 'CLASS: CommandLineEventConsumer MD5: %s NAME: %s COMMANDLINETEMPLATE: %s' % (hashEntry, CommandLineEventConsumer.wmi_property('Name').value, CommandLineEventConsumer.wmi_property('CommandLineTemplate').value))
                    ^
./plugins/loki-plugin-wmi.py:66:17: F821 undefined name 'logger'
                logger.log("INFO", "WMIScan", repr(str(CommandLineEventConsumer)))
                ^
./plugins/loki-plugin-wmi.py:68:13: F821 undefined name 'logger'
            logger.log("INFO", "WMIScan", repr(str(ActiveScriptEventConsumer)))
            ^
```