### PR TITLE
Add option to call other python bin 

### DIFF
--- a/loki.py
+++ b/loki.py
@@ -1380,7 +1380,7 @@ def updateLoki(sigsOnly):
     if os.path.exists(os.path.join(get_application_path(), 'loki-upgrader.exe')) and os_platform == "windows":
         pArgs.append('loki-upgrader.exe')
     elif os.path.exists(os.path.join(get_application_path(), 'loki-upgrader.py')):
-        pArgs.append('python')
+        pArgs.append(pargs.python)
         pArgs.append('loki-upgrader.py')
     else:
         logger.log("ERROR", "Update", "Cannot find neither thor-upgrader.exe nor thor-upgrader.py in the current working directory.")
@@ -1446,6 +1446,7 @@ def main():
     parser.add_argument('--logfolder', help='Folder to use for logging when log file is not specified', metavar='log-folder', default='')
     parser.add_argument('--nopesieve', action='store_true', help='Do not perform pe-sieve scans', default=False)
     parser.add_argument('--pesieveshellc', action='store_true', help='Perform pe-sieve shellcode scan', default=False)
+    parser.add_argument('--python', action='store', help='Override default python path', default='python')
     parser.add_argument('--nolisten', action='store_true', help='Dot not show listening connections', default=False)
     parser.add_argument('--excludeprocess', action='append', help='Specify an executable name to exclude from scans, can be used multiple times', default=[])
     parser.add_argument('--force', action='store_true',


### PR DESCRIPTION
Add option to call other python bin (for platforms which don't link python2/3 by default, such as kali)