### PR TITLE
Fix filescan issues (file format and uninitialized variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Hash;Description [Reference]
 
 For Filename IOCs (divided by newline)
 ```
-Filename as Regex;Description [Reference]
+# (optional) Description [Reference]
+Filename as Regex[;Score as integer[;False-positive as Regex]]
 ```
 
 # User-Defined Scan Excludes

--- a/loki.py
+++ b/loki.py
@@ -1027,6 +1027,10 @@ class Loki(object):
 
                         # Last Comment Line
                         last_comment = ""
+                        # Initialize score variable
+                        score = 0
+                        # Initialize empty description
+                        desc = ""
 
                         for line in lines:
                             try:


### PR DESCRIPTION
The documentation (inside `README.md`) and the expected file format for "File Name IOCs" doesn't match which leads to several issues. The most severe being that detections aren't reported (due to the the overly broad `except Exception as e:`), since a "Description" can't be casted to an integer (as the 2nd value is expected to be the score and not the description, now):
```
\Traceback (most recent call last):
  File "C:\Users\homesen\Desktop\Loki\loki.py", line 314, in scan_path
    total_score += int(fioc['score'])
ValueError: invalid literal for int() with base 10: 'Description [Reference]'
```

Also, the `initialize_filename_iocs` functions allows (according to its code) entries with only the file name Regex. This in turn causes an exception which results in the Regex not getting added to the list of IOCs:
```
Traceback (most recent call last):
  File "C:\Users\homesen\Desktop\Loki\loki.py", line 1071, in initialize_filename_iocs
    fioc = {'regex': re.compile(regex), 'score': score, 'description': desc, 'regex_fp': regex_fp_comp}
UnboundLocalError: local variable 'score' referenced before assignment
```
