### PR TITLE
Fixed comparison issue

### DIFF
--- a/loki.py
+++ b/loki.py
@@ -662,9 +662,9 @@ class Loki(object):
             for fioc in self.filename_iocs:
                 match = fioc['regex'].search(cmd)
                 if match:
-                    if fioc['score'] > 70:
+                    if int(fioc['score']) > 70:
                         logger.log("ALERT", "ProcessScan", "File Name IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
-                    elif fioc['score'] > 40:
+                    elif int(fioc['score']) > 40:
                         logger.log("WARNING", "ProcessScan", "File Name Suspicious IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
 
             # Suspicious waitfor - possible backdoor https://twitter.com/subTee/status/872274262769500160


### PR DESCRIPTION
Fix of TypeError when a running process was matched by filename IoCs:
**Traceback (most recent call last):
  File "C:\Loki\loki.py", line 1569, in <module>
  File "C:\Loki\loki.py", line 665, in scan_processes
TypeError: '>' not supported between instances of 'str' and 'int'
[8564] Failed to execute script loki**