### PR TITLE
Replace flake8, isort, and pyupgrade with ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,20 +4,17 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install black codespell flake8 isort mypy pytest pyupgrade safety
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install black codespell mypy pytest ruff safety
       - run: black --check . || true
       - run: codespell --ignore-words-list="datas" --skip="./.git/*"
-      - run: flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --show-source --statistics
-      - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt
+      - run: ruff --format=github --select=E9,F63,F7,F82 .
+      - run: ruff --exit-zero --format=github .
       - run: mypy --install-types --non-interactive . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: python ./loki.py --noprocs --noindicator --dontwait --debug -p ./test
       - run: python ./loki.py --noprocs --noindicator --dontwait --debug --intense -p ./test
       - run: python ./loki.py --noprocs --noindicator --dontwait --debug --csv -p ./test
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

Running `ruff --format=github .` in GitHub Actions will rapidly provide intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)