### PR TITLE
PEP8: Do not use bare except

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v5
       - run: pip install --upgrade pip setuptools wheel
       - run: pip install codespell mypy pytest ruff safety
-      - run: ruff check --output-format=github --ignore=E501,E701,E713,E722,F401,F403,F405,F841 --line-length=263 .
+      - run: ruff check --output-format=github --ignore=E701,F401,F403,F405,F841 --line-length=263
       - run: ruff format || true
       - run: codespell --ignore-words-list="datas" --skip="./.git/*"
       - run: pip install -r requirements.txt

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -32,27 +32,23 @@ def is_ip(string):
         if netaddr.valid_ipv6(string):
             return True
         return False
-    except:
+    except Exception:
         traceback.print_exc()
         return False
 
 
 def is_cidr(string):
     try:
-        if netaddr.IPNetwork(string) and "/" in string:
-            return True
-        return False
-    except:
+        return netaddr.IPNetwork(string) and "/" in string
+    except Exception:
         return False
 
 
 def ip_in_net(ip, network):
     try:
         # print "Checking if ip %s is in network %s" % (ip, network)
-        if netaddr.IPAddress(ip) in netaddr.IPNetwork(network):
-            return True
-        return False
-    except:
+        return netaddr.IPAddress(ip) in netaddr.IPNetwork(network)
+    except Exception:
         return False
 
 

--- a/loki.py
+++ b/loki.py
@@ -565,7 +565,7 @@ class Loki(object):
                     string_value = string_value[:140] + " ... (truncated)"
                 matching_strings.append("{0}: '{1}'".format(string.identifier, string_value))
             return matching_strings
-        except:
+        except Exception:
             traceback.print_exc()
 
     def check_svchost_owner(self, owner):

--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -30,19 +30,19 @@ def ScanWMI():
         lActiveScriptEventConsumer = []
         try:
             leventFilter = oWMI.__eventFilter()
-        except:
+        except Exception:
             logger.log("WARNING", "WMIScan", 'Error retrieving __eventFilter')
         try:
             lFilterToConsumerBinding = oWMI.__FilterToConsumerBinding()
-        except:
+        except Exception:
             logger.log("WARNING", "WMIScan", 'Error retrieving __FilterToConsumerBinding')
         try:
             lCommandLineEventConsumer = oWMI.CommandLineEventConsumer()
-        except:
+        except Exception:
             logger.log("WARNING", "WMIScan", 'Error retrieving CommandLineEventConsumer')
         try:
             lActiveScriptEventConsumer = oWMI.ActiveScriptEventConsumer()
-        except:
+        except Exception:
             logger.log("WARNING", "WMIScan", 'Error retrieving ActiveScriptEventConsumer')
 
         for eventFilter in leventFilter:
@@ -50,21 +50,21 @@ def ScanWMI():
                 hashEntry = hashlib.md5(str(eventFilter)).hexdigest()
                 if hashEntry not in knownHashes:
                     logger.log("WARNING", "WMIScan", 'CLASS: __eventFilter MD5: %s NAME: %s QUERY: %s' % (hashEntry, eventFilter.wmi_property('Name').value, eventFilter.wmi_property('Query').value))
-            except:
+            except Exception:
                 logger.log("INFO", "WMIScan", repr(str(eventFilter)))
         for FilterToConsumerBinding in lFilterToConsumerBinding:
             try:
                 hashEntry = hashlib.md5(str(FilterToConsumerBinding)).hexdigest()
                 if hashEntry not in knownHashes:
                     logger.log("WARNING", "WMIScan", 'CLASS: __FilterToConsumerBinding MD5: %s CONSUMER: %s FILTER: %s' % (hashEntry, FilterToConsumerBinding.wmi_property('Consumer').value, FilterToConsumerBinding.wmi_property('Filter').value))
-            except:
+            except Exception:
                 logger.log("INFO", "WMIScan", repr(str(FilterToConsumerBinding)))
         for CommandLineEventConsumer in lCommandLineEventConsumer:
             try:
                 hashEntry = hashlib.md5(str(CommandLineEventConsumer)).hexdigest()
                 if hashEntry not in knownHashes:
                     logger.log("WARNING", "WMIScan", 'CLASS: CommandLineEventConsumer MD5: %s NAME: %s COMMANDLINETEMPLATE: %s' % (hashEntry, CommandLineEventConsumer.wmi_property('Name').value, CommandLineEventConsumer.wmi_property('CommandLineTemplate').value))
-            except:
+            except Exception:
                 logger.log("INFO", "WMIScan", repr(str(CommandLineEventConsumer)))
         for ActiveScriptEventConsumer in lActiveScriptEventConsumer:
             logger.log("INFO", "WMIScan", repr(str(ActiveScriptEventConsumer)))


### PR DESCRIPTION
% `ruff check --select=E722 --output-format=concise`
```
lib/helpers.py:35:5: E722 Do not use bare `except`
lib/helpers.py:45:5: E722 Do not use bare `except`
lib/helpers.py:55:5: E722 Do not use bare `except`
loki.py:568:9: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:33:9: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:37:9: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:41:9: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:45:9: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:53:13: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:60:13: E722 Do not use bare `except`
plugins/loki-plugin-wmi.py:67:13: E722 Do not use bare `except`
Found 11 errors.
```
% [`ruff rule E722`](https://docs.astral.sh/ruff/rules/bare-except)
# bare-except (E722)

Derived from the **pycodestyle** linter.

## What it does
Checks for bare `except` catches in `try`-`except` statements.

## Why is this bad?
A bare `except` catches `BaseException` which includes
`KeyboardInterrupt`, `SystemExit`, `Exception`, and others. Catching
`BaseException` can make it hard to interrupt the program (e.g., with
Ctrl-C) and can disguise other problems.

## Example
```python
try:
    raise KeyboardInterrupt("You probably don't mean to break CTRL-C.")
except:
    print("But a bare `except` will ignore keyboard interrupts.")
```

Use instead:
```python
try:
    do_something_that_might_break()
except MoreSpecificException as e:
    handle_error(e)
```

If you actually need to catch an unknown error, use `Exception` which will
catch regular program errors but not important system exceptions.

```python
def run_a_function(some_other_fn):
    try:
        some_other_fn()
    except Exception as e:
        print(f"How exceptional! {e}")
```

## References
- [Python documentation: Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)
- [Google Python Style Guide: "Exceptions"](https://google.github.io/styleguide/pyguide.html#24-exceptions)
