### PR TITLE
Refactored logger to use enum for mes_type

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -23,6 +23,8 @@ import threading
 import subprocess
 import signal
 
+from utils.enums import MesType
+
 # Helper Functions -------------------------------------------------------------
 
 def is_ip(string):
@@ -83,13 +85,13 @@ def setNice(logger):
     try:
         pid = os.getpid()
         p = psutil.Process(pid)
-        logger.log("INFO", "Init", "Setting LOKI process with PID: %s to priority IDLE" % pid)
+        logger.log(MesType.INFO, "Init", "Setting LOKI process with PID: %s to priority IDLE" % pid)
         p.nice(psutil.IDLE_PRIORITY_CLASS)
         return 1
     except Exception:
         if logger.debug:
             traceback.print_exc()
-        logger.log("ERROR", "Init", "Error setting nice value of THOR process")
+        logger.log(MesType.ERROR, "Init", "Error setting nice value of THOR process")
         return 0
 
 

--- a/lib/pesieve.py
+++ b/lib/pesieve.py
@@ -9,6 +9,8 @@ import traceback
 from lib.lokilogger import *
 from lib.helpers import runProcess
 
+from utils.enums import MesType
+
 class PESieve(object):
     """
     PESieve class makes use of hasherezade's PE-Sieve tool to scans a given process,
@@ -27,10 +29,10 @@ class PESieve(object):
 
         if self.isAvailable():
             self.active = True
-            self.logger.log("NOTICE", "PESieve", "PE-Sieve successfully initialized BINARY: {0} "
+            self.logger.log(MesType.NOTICE, "PESieve", "PE-Sieve successfully initialized BINARY: {0} "
                                       "SOURCE: https://github.com/hasherezade/pe-sieve".format(self.peSieve))
         else:
-            self.logger.log("NOTICE", "PESieve", "Cannot find PE-Sieve in expected location {0} "
+            self.logger.log(MesType.NOTICE, "PESieve", "Cannot find PE-Sieve in expected location {0} "
                                       "SOURCE: https://github.com/hasherezade/pe-sieve".format(self.peSieve))
 
     def isAvailable(self):
@@ -39,7 +41,7 @@ class PESieve(object):
         :return:
         """
         if not os.path.exists(self.peSieve):
-            self.logger.log("DEBUG", "PESieve", "PE-Sieve not found in location '{0}' - "
+            self.logger.log(MesType.DEBUG, "PESieve", "PE-Sieve not found in location '{0}' - "
                                      "feature will not be active".format(self.peSieve))
             return False
         return True
@@ -63,12 +65,12 @@ class PESieve(object):
             return results
         try:
             results_raw = json.loads(output)
-            #results = results_raw["scan_report"]["scanned"]["modified"]
-            results = results_raw["scanned"]["modified"]
+            results = results_raw["scan_report"]["scanned"]["modified"]
+            #results = results_raw["scanned"]["modified"]
         except ValueError:
             traceback.print_exc()
-            self.logger.log("DEBUG", "PESieve", "Couldn't parse the JSON output.")
+            self.logger.log(MesType.DEBUG, "PESieve", "Couldn't parse the JSON output.")
         except Exception:
             traceback.print_exc()
-            self.logger.log("ERROR", "PESieve", "Something went wrong during PE-Sieve scan.")
+            self.logger.log(MesType.ERROR, "PESieve", "Something went wrong during PE-Sieve scan.")
         return results

--- a/lib/vuln_checker.py
+++ b/lib/vuln_checker.py
@@ -6,6 +6,8 @@
 
 import subprocess
 
+from utils.enums import MesType
+
 class VulnChecker():
 
     def __init__(self, logger):
@@ -14,7 +16,7 @@ class VulnChecker():
         pass
 
     def run(self):
-        self.logger.log("INFO", "VulnChecker", "Starting vulnerability checks ...")
+        self.logger.log(MesType.INFO, "VulnChecker", "Starting vulnerability checks ...")
         self.check_sam_readable()
 
     def check_sam_readable(self):
@@ -35,7 +37,7 @@ class VulnChecker():
         # Check the output
         try:
             if r'BUILTIN\Users:(I)(RX)' in output.decode('latin1', errors='ignore'):
-                self.logger.log("WARNING", "VulnChecker",
+                self.logger.log(MesType.WARNING, "VulnChecker",
                                 "The Security Account Manager (SAM) database file C:\\Windows\\System32\\config\\SAM is "
                                 "readable by every user. This is caused by the Hive Permission Bug, which is problematic "
                                 "on systems that have System Protection configured for drive C: (see "
@@ -43,7 +45,7 @@ class VulnChecker():
                                 "windows-10-7a871c465fa5)")
                 return True
             else:
-                self.logger.log("DEBUG", "VulnChecker", "SAM Database isn't readable by every user.")
+                self.logger.log(MesType.DEBUG, "VulnChecker", "SAM Database isn't readable by every user.")
         except UnicodeDecodeError:
-            self.logger.log("ERROR", "VulnChecker", "Unicode decode error in SAM check")
+            self.logger.log(MesType.ERROR, "VulnChecker", "Unicode decode error in SAM check")
         return False

--- a/loki-upgrader.py
+++ b/loki-upgrader.py
@@ -30,6 +30,7 @@ if _platform == "win32":
 
 
 from lib.lokilogger import *
+from utils.enums import MesType
 
 # Platform
 platform = ""
@@ -90,12 +91,12 @@ class LOKIUpdater(object):
                 if needs_update(sig_url):
                     # Downloading current repository
                     try:
-                        self.logger.log("INFO", "Upgrader", "Downloading %s ..." % sig_url)
+                        self.logger.log(MesType.INFO, "Upgrader", "Downloading %s ..." % sig_url)
                         response = urlopen(sig_url)
                     except Exception:
                         if self.debug:
                             traceback.print_exc()
-                        self.logger.log("ERROR", "Upgrader", "Error downloading the signature database - "
+                        self.logger.log(MesType.ERROR, "Upgrader", "Error downloading the signature database - "
                                                             "check your Internet connection")
                         sys.exit(1)
 
@@ -103,7 +104,7 @@ class LOKIUpdater(object):
                     try:
                         sigDir = os.path.join(self.application_path, os.path.abspath('signature-base/'))
                         if clean:
-                            self.logger.log("INFO", "Upgrader", "Cleaning directory '%s'" % sigDir)
+                            self.logger.log(MesType.INFO, "Upgrader", "Cleaning directory '%s'" % sigDir)
                             shutil.rmtree(sigDir)
                         for outDir in ['', 'iocs', 'yara', 'misc']:
                             fullOutDir = os.path.join(sigDir, outDir)
@@ -112,7 +113,7 @@ class LOKIUpdater(object):
                     except Exception:
                         if self.debug:
                             traceback.print_exc()
-                        self.logger.log("ERROR", "Upgrader", "Error while creating the signature-base directories")
+                        self.logger.log(MesType.ERROR, "Upgrader", "Error while creating the signature-base directories")
                         sys.exit(1)
 
                     # Read ZIP file
@@ -126,12 +127,12 @@ class LOKIUpdater(object):
                             skip = False
                             for incompatible_rule in self.INCOMPATIBLE_RULES:
                                 if sigName.endswith(incompatible_rule):
-                                    self.logger.log("NOTICE", "Upgrader", "Skipping incompatible rule %s" % sigName)
+                                    self.logger.log(MesType.NOTICE, "Upgrader", "Skipping incompatible rule %s" % sigName)
                                     skip = True
                             if skip:
                                 continue
                             # Extract the rules
-                            self.logger.log("DEBUG", "Upgrader", "Extracting %s ..." % zipFilePath)
+                            self.logger.log(MesType.DEBUG, "Upgrader", "Extracting %s ..." % zipFilePath)
                             if "/iocs/" in zipFilePath and zipFilePath.endswith(".txt"):
                                 targetFile = os.path.join(sigDir, "iocs", sigName)
                             elif "/yara/" in zipFilePath and zipFilePath.endswith(".yar"):
@@ -145,7 +146,7 @@ class LOKIUpdater(object):
 
                             # New file
                             if not os.path.exists(targetFile):
-                                self.logger.log("INFO", "Upgrader", "New signature file: %s" % sigName)
+                                self.logger.log(MesType.INFO, "Upgrader", "New signature file: %s" % sigName)
 
                             # Extract file
                             source = zipUpdate.open(zipFilePath)
@@ -158,11 +159,11 @@ class LOKIUpdater(object):
                     except Exception:
                         if self.debug:
                             traceback.print_exc()
-                        self.logger.log("ERROR", "Upgrader", "Error while extracting the signature files from the download "
+                        self.logger.log(MesType.ERROR, "Upgrader", "Error while extracting the signature files from the download "
                                                             "package")
                         sys.exit(1)
                 else:
-                    self.logger.log("INFO", "Upgrader", "%s is up to date." % sig_url)
+                    self.logger.log(MesType.INFO, "Upgrader", "%s is up to date." % sig_url)
 
         except Exception:
             if self.debug:
@@ -176,17 +177,17 @@ class LOKIUpdater(object):
 
             # Downloading the info for latest release
             try:
-                self.logger.log("INFO", "Upgrader", "Checking location of latest release %s ..." % self.UPDATE_URL_LOKI)
+                self.logger.log(MesType.INFO, "Upgrader", "Checking location of latest release %s ..." % self.UPDATE_URL_LOKI)
                 response_info = urlopen(self.UPDATE_URL_LOKI)
                 data = json.load(response_info)
                 # Get download URL
                 zip_url = data['assets'][0]['browser_download_url']
-                self.logger.log("INFO", "Upgrader", "Downloading latest release %s ..." % zip_url)
+                self.logger.log(MesType.INFO, "Upgrader", "Downloading latest release %s ..." % zip_url)
                 response_zip = urlopen(zip_url)
             except Exception:
                 if self.debug:
                     traceback.print_exc()
-                self.logger.log("ERROR", "Upgrader", "Error downloading the loki update - check your Internet connection")
+                self.logger.log(MesType.ERROR, "Upgrader", "Error downloading the loki update - check your Internet connection")
                 sys.exit(1)
 
             # Read ZIP file
@@ -199,7 +200,7 @@ class LOKIUpdater(object):
                     source = zipUpdate.open(zipFilePath)
                     targetFile = "/".join(zipFilePath.split("/")[1:])
 
-                    self.logger.log("INFO", "Upgrader", "Extracting %s ..." %targetFile)
+                    self.logger.log(MesType.INFO, "Upgrader", "Extracting %s ..." %targetFile)
 
                     try:
                         # Create file if not present
@@ -208,7 +209,7 @@ class LOKIUpdater(object):
                                 os.makedirs(os.path.dirname(targetFile))
                     except Exception:
                         if self.debug:
-                            self.logger.log("DEBUG", "Upgrader", "Cannot create dir name '%s'" % os.path.dirname(targetFile))
+                            self.logger.log(MesType.DEBUG, "Upgrader", "Cannot create dir name '%s'" % os.path.dirname(targetFile))
                             traceback.print_exc()
 
                     try:
@@ -217,17 +218,17 @@ class LOKIUpdater(object):
                         with source, target:
                             shutil.copyfileobj(source, target)
                             if self.debug:
-                                self.logger.log("DEBUG", "Upgrader", "Successfully extracted '%s'" % targetFile)
+                                self.logger.log(MesType.DEBUG, "Upgrader", "Successfully extracted '%s'" % targetFile)
                         target.close()
                     except Exception:
-                        self.logger.log("ERROR", "Upgrader", "Cannot extract '%s'" % targetFile)
+                        self.logger.log(MesType.ERROR, "Upgrader", "Cannot extract '%s'" % targetFile)
                         if self.debug:
                             traceback.print_exc()
 
             except Exception:
                 if self.debug:
                     traceback.print_exc()
-                self.logger.log("ERROR", "Upgrader",
+                self.logger.log(MesType.ERROR, "Upgrader",
                                 "Error while extracting the signature files from the download package")
                 sys.exit(1)
 
@@ -284,15 +285,15 @@ if __name__ == '__main__':
     updater = LOKIUpdater(args.debug, logger, get_application_path())
 
     if not args.sigsonly:
-        logger.log("INFO", "Upgrader", "Updating LOKI ...")
+        logger.log(MesType.INFO, "Upgrader", "Updating LOKI ...")
         updater.update_loki()
     if not args.progonly:
-        logger.log("INFO", "Upgrader", "Updating Signatures ...")
+        logger.log(MesType.INFO, "Upgrader", "Updating Signatures ...")
         updater.update_signatures(args.clean)
 
-    logger.log("INFO", "Upgrader", "Update complete")
+    logger.log(MesType.INFO, "Upgrader", "Update complete")
 
     if args.detached:
-        logger.log("INFO", "Upgrader", "Press any key to return ...")
+        logger.log(MesType.INFO, "Upgrader", "Press any key to return ...")
 
     sys.exit(0)

--- a/loki.py
+++ b/loki.py
@@ -48,6 +48,8 @@ from lib.pesieve import PESieve
 from lib.doublepulsar import DoublePulsar
 from lib.vuln_checker import VulnChecker
 
+from utils.enums import MesType
+
 # Platform
 os_platform = ""
 
@@ -138,7 +140,7 @@ class Loki(object):
         # Check if signature database is present
         sig_dir = os.path.join(self.app_path, "signature-base")
         if not os.path.exists(sig_dir) or os.listdir(sig_dir) == []:
-            logger.log("NOTICE", "Init", "The 'signature-base' subdirectory doesn't exist or is empty. "
+            logger.log(MesType.NOTICE, "Init", "The 'signature-base' subdirectory doesn't exist or is empty. "
                                          "Trying to retrieve the signature database automatically.")
             updateLoki(sigsOnly=True)
 
@@ -168,21 +170,21 @@ class Loki(object):
         # Read IOCs -------------------------------------------------------
         # File Name IOCs (all files in iocs that contain 'filename')
         self.initialize_filename_iocs(self.ioc_path)
-        logger.log("INFO", "Init", "File Name Characteristics initialized with %s regex patterns" % len(self.filename_iocs))
+        logger.log(MesType.INFO, "Init", "File Name Characteristics initialized with %s regex patterns" % len(self.filename_iocs))
 
         # C2 based IOCs (all files in iocs that contain 'c2')
         self.initialize_c2_iocs(self.ioc_path)
-        logger.log("INFO", "Init", "C2 server indicators initialized with %s elements" % len(self.c2_server.keys()))
+        logger.log(MesType.INFO, "Init", "C2 server indicators initialized with %s elements" % len(self.c2_server.keys()))
 
         # Hash based IOCs (all files in iocs that contain 'hash')
         self.initialize_hash_iocs(self.ioc_path)
-        logger.log("INFO", "Init", "Malicious MD5 Hashes initialized with %s hashes" % len(self.hashes_md5.keys()))
-        logger.log("INFO", "Init", "Malicious SHA1 Hashes initialized with %s hashes" % len(self.hashes_sha1.keys()))
-        logger.log("INFO", "Init", "Malicious SHA256 Hashes initialized with %s hashes" % len(self.hashes_sha256.keys()))
+        logger.log(MesType.INFO, "Init", "Malicious MD5 Hashes initialized with %s hashes" % len(self.hashes_md5.keys()))
+        logger.log(MesType.INFO, "Init", "Malicious SHA1 Hashes initialized with %s hashes" % len(self.hashes_sha1.keys()))
+        logger.log(MesType.INFO, "Init", "Malicious SHA256 Hashes initialized with %s hashes" % len(self.hashes_sha256.keys()))
 
         # Hash based False Positives (all files in iocs that contain 'hash' and 'falsepositive')
         self.initialize_hash_iocs(self.ioc_path, false_positive=True)
-        logger.log("INFO", "Init", "False Positive Hashes initialized with %s hashes" % len(self.false_hashes.keys()))
+        logger.log(MesType.INFO, "Init", "False Positive Hashes initialized with %s hashes" % len(self.false_hashes.keys()))
 
         # Compile Yara Rules
         self.initialize_yara_rules()
@@ -198,15 +200,15 @@ class Loki(object):
 
         # Check if path exists
         if not os.path.exists(path):
-            logger.log("ERROR", "FileScan", "None Existing Scanning Path %s ...  " % path)
+            logger.log(MesType.ERROR, "FileScan", "None Existing Scanning Path %s ...  " % path)
             return
 
         # Startup
-        logger.log("INFO", "FileScan", "Scanning Path %s ...  " % path)
+        logger.log(MesType.INFO, "FileScan", "Scanning Path %s ...  " % path)
         # Platform specific excludes
         for skip in self.startExcludes:
             if path.startswith(skip):
-                logger.log("INFO", "FileScan",
+                logger.log(MesType.INFO, "FileScan",
                            "Skipping %s directory [fixed excludes] (try using --force, --allhds or --alldrives)" % skip)
                 return
 
@@ -226,7 +228,7 @@ class Loki(object):
                 # Platform specific excludes
                 for skip in self.startExcludes:
                     if completePath.startswith(skip):
-                        logger.log("INFO", "FileScan", "Skipping %s directory [fixed excludes] (try using --force, --allhds or --alldrives)" % skip)
+                        logger.log(MesType.INFO, "FileScan", "Skipping %s directory [fixed excludes] (try using --force, --allhds or --alldrives)" % skip)
                         skipIt = True
 
                 if not skipIt:
@@ -263,7 +265,7 @@ class Loki(object):
                     # User defined excludes
                     for skip in self.fullExcludes:
                         if skip.search(filePath):
-                            logger.log("DEBUG", "FileScan", "Skipping element %s" % filePath)
+                            logger.log(MesType.DEBUG, "FileScan", "Skipping element %s" % filePath)
                             skipIt = True
 
                     # Linux directory skip
@@ -273,7 +275,7 @@ class Loki(object):
                         for skip in self.LINUX_PATH_SKIPS_END:
                             if filePath.endswith(skip):
                                 if self.LINUX_PATH_SKIPS_END[skip] == 0:
-                                    logger.log("INFO", "FileScan", "Skipping %s element" % skip)
+                                    logger.log(MesType.INFO, "FileScan", "Skipping %s element" % skip)
                                     self.LINUX_PATH_SKIPS_END[skip] = 1
                                     skipIt = True
 
@@ -295,7 +297,7 @@ class Loki(object):
                     # Skip program directory
                     # print appPath.lower() +" - "+ filePath.lower()
                     if self.app_path.lower() in filePath.lower():
-                        logger.log("DEBUG", "FileScan", "Skipping file in program directory FILE: %s" % filePathCleaned)
+                        logger.log(MesType.DEBUG, "FileScan", "Skipping file in program directory FILE: %s" % filePathCleaned)
                         continue
 
                     fileSize = os.stat(filePath).st_size
@@ -330,7 +332,7 @@ class Loki(object):
                         with open(filePath, 'rb') as f:
                             firstBytes = f.read(4)
                     except Exception:
-                        logger.log("DEBUG", "FileScan", "Cannot open file %s (access denied)" % filePathCleaned)
+                        logger.log(MesType.DEBUG, "FileScan", "Cannot open file %s (access denied)" % filePathCleaned)
 
                     # Evaluate Type
                     fileType = get_file_type(filePath, self.filetype_magics, self.max_filetype_magics, logger)
@@ -339,7 +341,7 @@ class Loki(object):
                     do_intense_check = True
                     if not self.intense_mode and fileType == "UNKNOWN" and extension not in EVIL_EXTENSIONS:
                         if args.printall:
-                            logger.log("INFO", "FileScan", "Skipping file due to fast scan mode: %s" % fileNameCleaned)
+                            logger.log(MesType.INFO, "FileScan", "Skipping file due to fast scan mode: %s" % fileNameCleaned)
                         do_intense_check = False
 
                     # Set fileData to an empty value
@@ -363,13 +365,13 @@ class Loki(object):
                     # Intense Check switch
                     if do_intense_check:
                         if args.printall:
-                            logger.log("INFO", "FileScan", "Scanning %s TYPE: %s SIZE: %s" % (fileNameCleaned, fileType, fileSize))
+                            logger.log(MesType.INFO, "FileScan", "Scanning %s TYPE: %s SIZE: %s" % (fileNameCleaned, fileType, fileSize))
                     else:
                         if args.printall:
-                            logger.log("INFO", "FileScan", "Checking %s TYPE: %s SIZE: %s" % (fileNameCleaned, fileType, fileSize))
+                            logger.log(MesType.INFO, "FileScan", "Checking %s TYPE: %s SIZE: %s" % (fileNameCleaned, fileType, fileSize))
 
                     if print_filesize_info and args.printall:
-                        logger.log("INFO", "FileScan", "Skipping file due to file size: %s TYPE: %s SIZE: %s CURRENT SIZE LIMIT(kilobytes): %d" % (fileNameCleaned, fileType, fileSize, fileSizeLimit))
+                        logger.log(MesType.INFO, "FileScan", "Skipping file due to file size: %s TYPE: %s SIZE: %s CURRENT SIZE LIMIT(kilobytes): %d" % (fileNameCleaned, fileType, fileSize, fileSizeLimit))
 
                     # Hash Check -------------------------------------------------------
                     # Do the check
@@ -431,7 +433,7 @@ class Loki(object):
                         # Script Anomalies Check
                         if args.scriptanalysis:
                             if extension in SCRIPT_EXTENSIONS or type in SCRIPT_TYPES:
-                                logger.log("DEBUG", "FileScan", "Performing character analysis on file %s ... " % filePath)
+                                logger.log(MesType.DEBUG, "FileScan", "Performing character analysis on file %s ... " % filePath)
                                 message, score = self.script_stats_analysis(fileData)
                                 if message:
                                     reasons.append("%s SCORE: %s" % (message, score))
@@ -441,7 +443,7 @@ class Loki(object):
 
                         # Memory Dump Scan
                         if fileType == "MDMP":
-                            logger.log("INFO", "FileScan", "Scanning memory dump file %s" % fileNameCleaned.decode('utf-8'))
+                            logger.log(MesType.INFO, "FileScan", "Scanning memory dump file %s" % fileNameCleaned.decode('utf-8'))
 
                         # Scan the read data
                         try:
@@ -466,7 +468,7 @@ class Loki(object):
                         except Exception:
                             if logger.debug:
                                 traceback.print_exc()
-                            logger.log("ERROR", "FileScan", "Cannot YARA scan file: %s" % filePathCleaned)
+                            logger.log(MesType.ERROR, "FileScan", "Cannot YARA scan file: %s" % filePathCleaned)
 
                     # Info Line -----------------------------------------------------------------------
                     fileInfo = "FILE: %s SCORE: %s TYPE: %s SIZE: %s FIRST_BYTES: %s %s %s " % (
@@ -474,11 +476,11 @@ class Loki(object):
 
                     # Now print the total result
                     if total_score >= args.a:
-                        message_type = "ALERT"
+                        message_type = MesType.ALERT
                     elif total_score >= args.w:
-                        message_type = "WARNING"
+                        message_type = MesType.WARNING
                     elif total_score >= args.n:
-                        message_type = "NOTICE"
+                        message_type = MesType.NOTICE
 
                     if total_score < args.n:
                         continue
@@ -636,7 +638,7 @@ class Loki(object):
                     owner = "unknown"
 
             except Exception:
-                logger.log("ALERT", "ProcessScan", "Error getting all process information. Did you run the scanner 'As Administrator'?")
+                logger.log(MesType.ALERT, "ProcessScan", "Error getting all process information. Did you run the scanner 'As Administrator'?")
                 continue
 
             # Is parent to other processes - save PID
@@ -653,33 +655,33 @@ class Loki(object):
 
             # Skip some PIDs ------------------------------------------------------
             if pid == 0 or pid == 4:
-                logger.log("INFO", "ProcessScan", "Skipping Process %s" % process_info)
+                logger.log(MesType.INFO, "ProcessScan", "Skipping Process %s" % process_info)
                 continue
 
             # Skip own process ----------------------------------------------------
             if loki_pid == pid or loki_ppid == pid:
-                logger.log("INFO", "ProcessScan", "Skipping LOKI Process %s" % process_info)
+                logger.log(MesType.INFO, "ProcessScan", "Skipping LOKI Process %s" % process_info)
                 continue
 
             # Print info ----------------------------------------------------------
-            logger.log("INFO", "ProcessScan", "Scanning Process %s" % process_info)
+            logger.log(MesType.INFO, "ProcessScan", "Scanning Process %s" % process_info)
 
             # Skeleton Key Malware Process
             if re.search(r'psexec .* [a-fA-F0-9]{32}', cmd, re.IGNORECASE):
-                logger.log("WARNING", "ProcessScan", "Process that looks liks SKELETON KEY psexec execution detected %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "Process that looks liks SKELETON KEY psexec execution detected %s" % process_info)
 
             # File Name Checks -------------------------------------------------
             for fioc in self.filename_iocs:
                 match = fioc['regex'].search(cmd)
                 if match:
                     if int(fioc['score']) > 70:
-                        logger.log("ALERT", "ProcessScan", "File Name IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
+                        logger.log(MesType.ALERT, "ProcessScan", "File Name IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
                     elif int(fioc['score']) > 40:
-                        logger.log("WARNING", "ProcessScan", "File Name Suspicious IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
+                        logger.log(MesType.WARNING, "ProcessScan", "File Name Suspicious IOC matched PATTERN: %s DESC: %s MATCH: %s" % (fioc['regex'].pattern, fioc['description'], cmd))
 
             # Suspicious waitfor - possible backdoor https://twitter.com/subTee/status/872274262769500160
             if name == "waitfor.exe":
-                logger.log("WARNING", "ProcessScan", "Suspicious waitfor.exe process https://twitter.com/subTee/status/872274262769500160 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "Suspicious waitfor.exe process https://twitter.com/subTee/status/872274262769500160 %s" % process_info)
 
             # Yara rule match
             # only on processes with a small working set size
@@ -710,44 +712,44 @@ class Loki(object):
                                         alerts.append("Yara Rule MATCH: %s %s" % (match.rule, process_info))
 
                         if len(alerts) > 5:
-                            logger.log("WARNING", "ProcessScan", "Too many matches on process memory - most likely a false positive %s" % process_info)
+                            logger.log(MesType.WARNING, "ProcessScan", "Too many matches on process memory - most likely a false positive %s" % process_info)
                         elif len(alerts) > 0:
                             for alert in alerts:
-                                logger.log("ALERT", "ProcessScan", alert)
+                                logger.log(MesType.ALERT, "ProcessScan", alert)
                     except Exception:
                         if logger.debug:
                             traceback.print_exc()
                         if path != "none":
-                            logger.log("ERROR", "ProcessScan", "Error during process memory Yara check (maybe the process doesn't exist anymore or access denied) %s" % process_info)
+                            logger.log(MesType.ERROR, "ProcessScan", "Error during process memory Yara check (maybe the process doesn't exist anymore or access denied) %s" % process_info)
                 else:
-                    logger.log("DEBUG", "ProcessScan", "Skipped Yara memory check due to the process' big working set size (stability issues) PID: %s NAME: %s SIZE: %s" % ( pid, name, ws_size))
+                    logger.log(MesType.DEBUG, "ProcessScan", "Skipped Yara memory check due to the process' big working set size (stability issues) PID: %s NAME: %s SIZE: %s" % ( pid, name, ws_size))
 
             ###############################################################
             # PE-Sieve Checks
             try:
                 if processExists(pid) and self.peSieve.active and not nopesieve:
                         # If PE-Sieve reports replaced processes
-                        logger.log("DEBUG", "ProcessScan", "PE-Sieve scan of process PID: %s" % pid)
+                        logger.log(MesType.DEBUG, "ProcessScan", "PE-Sieve scan of process PID: %s" % pid)
                         results = self.peSieve.scan(pid, pesieveshellc)
                         if results["replaced"]:
-                            logger.log("WARNING", "ProcessScan", "PE-Sieve reported replaced process %s REPLACED: %s" %
+                            logger.log(MesType.WARNING, "ProcessScan", "PE-Sieve reported replaced process %s REPLACED: %s" %
                                        (process_info, str(results["replaced"])))
                         elif results["implanted_pe"] or results["implanted_shc"]:
-                            logger.log("WARNING", "ProcessScan", "PE-Sieve reported implanted process %s "
+                            logger.log(MesType.WARNING, "ProcessScan", "PE-Sieve reported implanted process %s "
                                        "IMPLANTED PE: %s IMPLANTED SHC: %s" % (process_info, str(results["implanted_pe"]),
                                                                                 str(results["implanted_shc"])) )
                         elif results["patched"]:
-                            logger.log("NOTICE", "ProcessScan", "PE-Sieve reported patched process %s PATCHED: %s" %
+                            logger.log(MesType.NOTICE, "ProcessScan", "PE-Sieve reported patched process %s PATCHED: %s" %
                                        (process_info, str(results["patched"])))
                         elif results["unreachable_file"]:
-                            logger.log("NOTICE", "ProcessScan", "PE-Sieve reported a process with unreachable exe %s UNREACHABLE: %s" %
+                            logger.log(MesType.NOTICE, "ProcessScan", "PE-Sieve reported a process with unreachable exe %s UNREACHABLE: %s" %
                                        (process_info, str(results["unreachable_file"])))
                         else:
-                            logger.log("INFO", "ProcessScan", "PE-Sieve reported no anomalies %s" % process_info)
+                            logger.log(MesType.INFO, "ProcessScan", "PE-Sieve reported no anomalies %s" % process_info)
             except WindowsError:
                 if logger.debug:
                     traceback.print_exc()
-                logger.log("ERROR", "ProcessScan",
+                logger.log(MesType.ERROR, "ProcessScan",
                            "Error while accessing process handle using PE-Sieve (use --debug for full traceback)")
 
             ###############################################################
@@ -761,30 +763,30 @@ class Loki(object):
 
             # Process: System
             if name == "System" and not pid == 4:
-                logger.log("WARNING", "ProcessScan", "System process without PID=4 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "System process without PID=4 %s" % process_info)
 
             # Process: smss.exe
             if name == "smss.exe" and not parent_pid == 4:
-                logger.log("WARNING", "ProcessScan", "smss.exe parent PID is != 4 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "smss.exe parent PID is != 4 %s" % process_info)
             if path != "none":
                 if name == "smss.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "smss.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "smss.exe path is not System32 %s" % process_info)
             if name == "smss.exe" and priority != 11:
-                logger.log("WARNING", "ProcessScan", "smss.exe priority is not 11 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "smss.exe priority is not 11 %s" % process_info)
 
             # Process: csrss.exe
             if path != "none":
                 if name == "csrss.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "csrss.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "csrss.exe path is not System32 %s" % process_info)
             if name == "csrss.exe" and priority != 13:
-                logger.log("WARNING", "ProcessScan", "csrss.exe priority is not 13 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "csrss.exe priority is not 13 %s" % process_info)
 
             # Process: wininit.exe
             if path != "none":
                 if name == "wininit.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "wininit.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "wininit.exe path is not System32 %s" % process_info)
             if name == "wininit.exe" and priority != 13:
-                logger.log("NOTICE", "ProcessScan", "wininit.exe priority is not 13 %s" % process_info)
+                logger.log(MesType.NOTICE, "ProcessScan", "wininit.exe priority is not 13 %s" % process_info)
             # Is parent to other processes - save PID
             if name == "wininit.exe":
                 wininit_pid = pid
@@ -792,71 +794,71 @@ class Loki(object):
             # Process: services.exe
             if path != "none":
                 if name == "services.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "services.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "services.exe path is not System32 %s" % process_info)
             if name == "services.exe" and priority != 9:
-                logger.log("WARNING", "ProcessScan", "services.exe priority is not 9 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "services.exe priority is not 9 %s" % process_info)
             if wininit_pid > 0:
                 if name == "services.exe" and not parent_pid == wininit_pid:
-                    logger.log("WARNING", "ProcessScan", "services.exe parent PID is not the one of wininit.exe %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "services.exe parent PID is not the one of wininit.exe %s" % process_info)
 
             # Process: lsass.exe
             if path != "none":
                 if name == "lsass.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "lsass.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "lsass.exe path is not System32 %s" % process_info)
             if name == "lsass.exe" and priority != 9:
-                logger.log("WARNING", "ProcessScan", "lsass.exe priority is not 9 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "lsass.exe priority is not 9 %s" % process_info)
             if wininit_pid > 0:
                 if name == "lsass.exe" and not parent_pid == wininit_pid:
-                    logger.log("WARNING", "ProcessScan", "lsass.exe parent PID is not the one of wininit.exe %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "lsass.exe parent PID is not the one of wininit.exe %s" % process_info)
             # Only a single lsass process is valid - count occurrences
             if name == "lsass.exe":
                 lsass_count += 1
                 if lsass_count > 1:
-                    logger.log("WARNING", "ProcessScan", "lsass.exe count is higher than 1 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "lsass.exe count is higher than 1 %s" % process_info)
 
             # Process: svchost.exe
             if path != "none":
                 if name == "svchost.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "svchost.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "svchost.exe path is not System32 %s" % process_info)
             if name == "svchost.exe" and priority != 8:
-                logger.log("NOTICE", "ProcessScan", "svchost.exe priority is not 8 %s" % process_info)
+                logger.log(MesType.NOTICE, "ProcessScan", "svchost.exe priority is not 8 %s" % process_info)
             # Windows 10 FP
             #if name == "svchost.exe" and not ( self.check_svchost_owner(owner) or "unistacksvcgroup" in cmd.lower()):
-            #    logger.log("WARNING", "ProcessScan", "svchost.exe process owner is suspicious %s" % process_info)
+            #    logger.log(MesType.WARNING, "ProcessScan", "svchost.exe process owner is suspicious %s" % process_info)
 
             if name == "svchost.exe" and " -k " not in cmd and cmd != "N/A":
-                logger.log("WARNING", "ProcessScan", "svchost.exe process does not contain a -k in its command line %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "svchost.exe process does not contain a -k in its command line %s" % process_info)
 
             # Process: lsm.exe
             if path != "none":
                 if name == "lsm.exe" and not ( "system32" in path.lower() or "system32" in cmd.lower() ):
-                    logger.log("WARNING", "ProcessScan", "lsm.exe path is not System32 %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "lsm.exe path is not System32 %s" % process_info)
             if name == "lsm.exe" and priority != 8:
-                logger.log("NOTICE", "ProcessScan", "lsm.exe priority is not 8 %s" % process_info)
+                logger.log(MesType.NOTICE, "ProcessScan", "lsm.exe priority is not 8 %s" % process_info)
             if name == "lsm.exe" and not ( owner.startswith("NT ") or owner.startswith("LO") or owner.startswith("SYSTEM")  or owner.startswith(u"система")):
-                logger.log(u"WARNING", "ProcessScan", "lsm.exe process owner is suspicious %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "lsm.exe process owner is suspicious %s" % process_info)
             if wininit_pid > 0:
                 if name == "lsm.exe" and not parent_pid == wininit_pid:
-                    logger.log("WARNING", "ProcessScan", "lsm.exe parent PID is not the one of wininit.exe %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "lsm.exe parent PID is not the one of wininit.exe %s" % process_info)
 
             # Process: winlogon.exe
             if name == "winlogon.exe" and priority != 13:
-                logger.log("WARNING", "ProcessScan", "winlogon.exe priority is not 13 %s" % process_info)
+                logger.log(MesType.WARNING, "ProcessScan", "winlogon.exe priority is not 13 %s" % process_info)
             if re.search("(Windows 7|Windows Vista)", getPlatformFull()):
                 if name == "winlogon.exe" and parent_pid > 0:
                     for proc in processes:
                         if parent_pid == proc.ProcessId:
-                            logger.log("WARNING", "ProcessScan", "winlogon.exe has a parent ID but should have none %s PARENTID: %s"
+                            logger.log(MesType.WARNING, "ProcessScan", "winlogon.exe has a parent ID but should have none %s PARENTID: %s"
                                        % (process_info, str(parent_pid)))
 
             # Process: explorer.exe
             if path != "none":
                 if name == "explorer.exe" and t_systemroot.lower() not in path.lower():
-                    logger.log("WARNING", "ProcessScan", "explorer.exe path is not %%SYSTEMROOT%% %s" % process_info)
+                    logger.log(MesType.WARNING, "ProcessScan", "explorer.exe path is not %%SYSTEMROOT%% %s" % process_info)
             if name == "explorer.exe" and parent_pid > 0:
                 for proc in processes:
                     if parent_pid == proc.ProcessId:
-                        logger.log("NOTICE", "ProcessScan", "explorer.exe has a parent ID but should have none %s" % process_info)
+                        logger.log(MesType.NOTICE, "ProcessScan", "explorer.exe has a parent ID but should have none %s" % process_info)
 
     def check_process_connections(self, process):
         try:
@@ -890,10 +892,10 @@ class Loki(object):
 
                 if x.status == 'LISTEN':
                     connection_count += 1
-                    logger.log("NOTICE", "ProcessScan", "Listening process PID: %s NAME: %s COMMAND: %s IP: %s PORT: %s" % (
+                    logger.log(MesType.NOTICE, "ProcessScan", "Listening process PID: %s NAME: %s COMMAND: %s IP: %s PORT: %s" % (
                         str(pid), name, command, str(x.laddr[0]), str(x.laddr[1]) ))
                     if str(x.laddr[1]) == "0":
-                        logger.log("WARNING", "ProcessScan",
+                        logger.log(MesType.WARNING, "ProcessScan",
                             "Listening on Port 0 PID: %s NAME: %s COMMAND: %s  IP: %s PORT: %s" % (
                                 str(pid), name, command, str(x.laddr[0]), str(x.laddr[1]) ))
 
@@ -905,55 +907,55 @@ class Loki(object):
                     # Check keyword in remote address
                     is_match, description = self.check_c2(str(x.raddr[0]))
                     if is_match:
-                        logger.log("ALERT", "ProcessScan",
+                        logger.log(MesType.ALERT, "ProcessScan",
                             "Malware Domain/IP match in remote address PID: %s NAME: %s COMMAND: %s IP: %s PORT: %s DESC: %s" % (
                                 str(pid), name, command, str(x.raddr[0]), str(x.raddr[1]), description))
 
                     # Full list
                     connection_count += 1
-                    logger.log("NOTICE", "ProcessScan",
+                    logger.log(MesType.NOTICE, "ProcessScan",
                                "Established connection PID: %s NAME: %s COMMAND: %s LIP: %s LPORT: %s RIP: %s RPORT: %s" % (
                         str(pid), name, command, str(x.laddr[0]), str(x.laddr[1]), str(x.raddr[0]), str(x.raddr[1]) ))
 
                 # Maximum connection output
                 if connection_count > MAXIMUM_CONNECTIONS:
-                    logger.log("NOTICE", "ProcessScan", "Connection output threshold reached. Output truncated.")
+                    logger.log(MesType.NOTICE, "ProcessScan", "Connection output threshold reached. Output truncated.")
                     return
 
         except Exception:
             if args.debug:
                 traceback.print_exc()
                 sys.exit(1)
-            logger.log("INFO", "ProcessScan",
+            logger.log(MesType.INFO, "ProcessScan",
                 "Process %s does not exist anymore or cannot be accessed" % str(pid))
 
     def check_rootkit(self):
 
-        logger.log("INFO", "Rootkit", "Checking for Backdoors ...")
+        logger.log(MesType.INFO, "Rootkit", "Checking for Backdoors ...")
 
         dp = DoublePulsar(ip="127.0.0.1", timeout=None, verbose=args.debug)
 
-        logger.log("INFO", "Rootkit", "Checking for Double Pulsar RDP Backdoor")
+        logger.log(MesType.INFO, "Rootkit", "Checking for Double Pulsar RDP Backdoor")
         try:
             dp_rdp_result, message = dp.check_ip_rdp()
             if dp_rdp_result:
-                logger.log("ALERT", message)
+                logger.log(MesType.ALERT, message)
             else:
-                logger.log("INFO", "Rootkit", "Double Pulsar RDP check RESULT: %s" % message)
+                logger.log(MesType.INFO, "Rootkit", "Double Pulsar RDP check RESULT: %s" % message)
         except Exception:
-            logger.log("INFO", "Rootkit", "Double Pulsar RDP check failed RESULT: Connection failure")
+            logger.log(MesType.INFO, "Rootkit", "Double Pulsar RDP check failed RESULT: Connection failure")
             if args.debug:
                 traceback.print_exc()
 
-        logger.log("INFO", "Rootkit", "Checking for Double Pulsar SMB Backdoor")
+        logger.log(MesType.INFO, "Rootkit", "Checking for Double Pulsar SMB Backdoor")
         try:
             dp_smb_result, message = dp.check_ip_smb()
             if dp_smb_result:
-                logger.log("ALERT", message)
+                logger.log(MesType.ALERT, message)
             else:
-                logger.log("INFO", "Rootkit", "Double Pulsar SMB check RESULT: %s" % message)
+                logger.log(MesType.INFO, "Rootkit", "Double Pulsar SMB check RESULT: %s" % message)
         except Exception:
-            logger.log("INFO", "Rootkit", "Double Pulsar SMB check failed RESULT: Connection failure")
+            logger.log(MesType.INFO, "Rootkit", "Double Pulsar SMB check failed RESULT: Connection failure")
             if args.debug:
                 traceback.print_exc()
 
@@ -1010,7 +1012,7 @@ class Loki(object):
 
                                     # Check length
                                     if len(c2) < 4:
-                                        logger.log("NOTICE", "Init",
+                                        logger.log(MesType.NOTICE, "Init",
                                                    "C2 server definition is suspiciously short - will not add %s" %c2)
                                         continue
 
@@ -1018,14 +1020,14 @@ class Loki(object):
                                     self.c2_server[c2.lower()] = last_comment
 
                                 except Exception:
-                                    logger.log("ERROR", "Init",  "Cannot read line: %s" % line)
+                                    logger.log(MesType.ERROR, "Init",  "Cannot read line: %s" % line)
                                     if logger.debug:
                                         sys.exit(1)
                 except OSError:
-                    logger.log("ERROR", "Init",  "No such file or directory")
+                    logger.log(MesType.ERROR, "Init",  "No such file or directory")
         except Exception:
             traceback.print_exc()
-            logger.log("ERROR", "Init", "Error reading Hash file: %s" % ioc_filename)
+            logger.log(MesType.ERROR, "Init", "Error reading Hash file: %s" % ioc_filename)
 
     def initialize_filename_iocs(self, ioc_directory):
 
@@ -1086,17 +1088,17 @@ class Loki(object):
                                 self.filename_iocs.append(fioc)
 
                             except Exception:
-                                logger.log("ERROR", "Init", "Error reading line: %s" % line)
+                                logger.log(MesType.ERROR, "Init", "Error reading line: %s" % line)
                                 if logger.debug:
                                     traceback.print_exc()
                                     sys.exit(1)
 
         except Exception:
             if 'ioc_filename' in locals():
-                logger.log("ERROR",  "Init", "Error reading IOC file: %s" % ioc_filename)
+                logger.log(MesType.ERROR,  "Init", "Error reading IOC file: %s" % ioc_filename)
             else:
-                logger.log("ERROR",  "Init", "Error reading files from IOC folder: %s" % ioc_directory)  
-                logger.log("ERROR",  "Init", "Please make sure that you cloned the repo or downloaded the sub repository: "
+                logger.log(MesType.ERROR,  "Init", "Error reading files from IOC folder: %s" % ioc_directory)  
+                logger.log(MesType.ERROR,  "Init", "Please make sure that you cloned the repo or downloaded the sub repository: "
                                              "See https://github.com/Neo23x0/Loki/issues/51")
             sys.exit(1)
 
@@ -1110,7 +1112,7 @@ class Loki(object):
             for yara_rule_directory in self.yara_rule_directories:
                 if not os.path.exists(yara_rule_directory):
                     continue
-                logger.log("INFO", "Init", "Processing YARA rules folder {0}".format(yara_rule_directory))
+                logger.log(MesType.INFO, "Init", "Processing YARA rules folder {0}".format(yara_rule_directory))
                 for root, directories, files in os.walk(yara_rule_directory, onerror=walk_error, followlinks=False):
                     for file in files:
                         try:
@@ -1141,10 +1143,10 @@ class Loki(object):
                                     'md5': dummy,
                                     'owner': dummy,
                                 })
-                                logger.log("DEBUG", "Init", "Initializing Yara rule %s" % file)
+                                logger.log(MesType.DEBUG, "Init", "Initializing Yara rule %s" % file)
                                 rule_count += 1
                             except Exception:
-                                logger.log("ERROR", "Init", "Error while initializing Yara rule %s ERROR: %s" % (file, sys.exc_info()[1]))
+                                logger.log(MesType.ERROR, "Init", "Error while initializing Yara rule %s ERROR: %s" % (file, sys.exc_info()[1]))
                                 traceback.print_exc()
                                 if logger.debug:
                                     sys.exit(1)
@@ -1154,14 +1156,14 @@ class Loki(object):
                             yaraRules += yara_rule_data
 
                         except Exception:
-                            logger.log("ERROR", "Init", "Error reading signature file %s ERROR: %s" % (yaraRuleFile, sys.exc_info()[1]))
+                            logger.log(MesType.ERROR, "Init", "Error reading signature file %s ERROR: %s" % (yaraRuleFile, sys.exc_info()[1]))
                             if logger.debug:
                                 traceback.print_exc()
                                 # sys.exit(1)
 
             # Compile
             try:
-                logger.log("INFO", "Init", "Initializing all YARA rules at once (composed string of all rule files)")
+                logger.log(MesType.INFO, "Init", "Initializing all YARA rules at once (composed string of all rule files)")
                 compiledRules = yara.compile(source=yaraRules, externals={
                     'filename': dummy,
                     'filepath': dummy,
@@ -1170,17 +1172,17 @@ class Loki(object):
                     'md5': dummy,
                     'owner': dummy,
                 })
-                logger.log("INFO", "Init", "Initialized %d Yara rules" % rule_count)
+                logger.log(MesType.INFO, "Init", "Initialized %d Yara rules" % rule_count)
             except Exception:
                 traceback.print_exc()
-                logger.log("ERROR", "Init", "Error during YARA rule compilation ERROR: %s - please fix the issue in the rule set" % sys.exc_info()[1])
+                logger.log(MesType.ERROR, "Init", "Error during YARA rule compilation ERROR: %s - please fix the issue in the rule set" % sys.exc_info()[1])
                 sys.exit(1)
 
             # Add as Lokis YARA rules
             self.yara_rules.append(compiledRules)
 
         except Exception:
-            logger.log("ERROR", "Init", "Error reading signature folder /signatures/")
+            logger.log(MesType.ERROR, "Init", "Error reading signature folder /signatures/")
             if logger.debug:
                 traceback.print_exc()
                 sys.exit(1)
@@ -1237,11 +1239,11 @@ class Loki(object):
                             except Exception:
                                 if logger.debug:
                                     traceback.print_exc()
-                                logger.log("ERROR", "Init", "Cannot read line: %s" % line)
+                                logger.log(MesType.ERROR, "Init", "Cannot read line: %s" % line)
 
                     # Debug
                     if logger.debug:
-                        logger.log("DEBUG", "Init", "Initialized %s hash IOCs from file %s"
+                        logger.log(MesType.DEBUG, "Init", "Initialized %s hash IOCs from file %s"
                                    % (str(len(self.hashes_md5)+len(self.hashes_sha1)+len(self.hashes_sha256)), ioc_filename))
 
             # create sorted lists with just the integer values of the hashes for quick binary search 
@@ -1256,7 +1258,7 @@ class Loki(object):
             if logger.debug:
                 traceback.print_exc()
                 sys.exit(1)
-            logger.log("ERROR", "Init", "Error reading Hash file: %s" % ioc_filename)
+            logger.log(MesType.ERROR, "Init", "Error reading Hash file: %s" % ioc_filename)
 
     def initialize_filetype_magics(self, filetype_magics_file):
         try:
@@ -1279,13 +1281,13 @@ class Loki(object):
                     self.filetype_magics[sig] = description
 
                 except Exception:
-                    logger.log("ERROR", "Init", "Cannot read line: %s" % line)
+                    logger.log(MesType.ERROR, "Init", "Cannot read line: %s" % line)
 
         except Exception:
             if logger.debug:
                 traceback.print_exc()
                 sys.exit(1)
-            logger.log("ERROR", "Init", "Error reading Hash file: %s" % filetype_magics_file)
+            logger.log(MesType.ERROR, "Init", "Error reading Hash file: %s" % filetype_magics_file)
 
     def initialize_excludes(self, excludes_file):
         try:
@@ -1302,14 +1304,14 @@ class Loki(object):
                         regex = re.compile(line, re.IGNORECASE)
                         excludes.append(regex)
                 except Exception:
-                    logger.log("ERROR", "Init", "Cannot compile regex: %s" % line)
+                    logger.log(MesType.ERROR, "Init", "Cannot compile regex: %s" % line)
 
             self.fullExcludes = excludes
 
         except Exception:
             if logger.debug:
                 traceback.print_exc()
-            logger.log("NOTICE", "Init", "Error reading excludes file: %s" % excludes_file)
+            logger.log(MesType.NOTICE, "Init", "Error reading excludes file: %s" % excludes_file)
 
 
     def get_file_data(self, filePath):
@@ -1321,7 +1323,7 @@ class Loki(object):
         except Exception:
             if logger.debug:
                 traceback.print_exc()
-            logger.log("DEBUG", "FileScan", "Cannot open file %s (access denied)" % filePath)
+            logger.log(MesType.DEBUG, "FileScan", "Cannot open file %s (access denied)" % filePath)
         finally:
             return fileData
 
@@ -1390,7 +1392,7 @@ def get_application_path():
             # print application_path
             application_path = win32api.GetLongPathName(application_path)
         #if args.debug:
-        #    logger.log("DEBUG", "Init", "Application Path: %s" % application_path)
+        #    logger.log(MesType.DEBUG, "Init", "Application Path: %s" % application_path)
         return application_path
     except Exception:
         print("Error while evaluation of application path")
@@ -1417,7 +1419,7 @@ def processExists(pid):
 
 
 def updateLoki(sigsOnly):
-    logger.log("INFO", "Update", "Starting separate updater process ...")
+    logger.log(MesType.INFO, "Update", "Starting separate updater process ...")
     pArgs = []
 
     # Updater
@@ -1427,7 +1429,7 @@ def updateLoki(sigsOnly):
         pArgs.append(args.python)
         pArgs.append('loki-upgrader.py')
     else:
-        logger.log("ERROR", "Update", "Cannot find neither thor-upgrader.exe nor thor-upgrader.py in the current working directory.")
+        logger.log(MesType.ERROR, "Update", "Cannot find neither thor-upgrader.exe nor thor-upgrader.py in the current working directory.")
 
     if sigsOnly:
         pArgs.append('--sigsonly')
@@ -1554,7 +1556,7 @@ if __name__ == '__main__':
         updateLoki(sigsOnly=False)
         sys.exit(0)
 
-    logger.log("NOTICE", "Init", "Starting Loki Scan VERSION: {3} SYSTEM: {0} TIME: {1} PLATFORM: {2}".format(
+    logger.log(MesType.NOTICE, "Init", "Starting Loki Scan VERSION: {3} SYSTEM: {0} TIME: {1} PLATFORM: {2}".format(
         getHostname(os_platform), getSyslogTimestamp(), getPlatformFull(), logger.version))
 
     # Loki
@@ -1565,15 +1567,15 @@ if __name__ == '__main__':
     if os_platform == "windows":
         if shell.IsUserAnAdmin():
             isAdmin = True
-            logger.log("INFO", "Init", "Current user has admin rights - very good")
+            logger.log(MesType.INFO, "Init", "Current user has admin rights - very good")
         else:
-            logger.log("NOTICE", "Init", "Program should be run 'as Administrator' to ensure all access rights to process memory and file objects.")
+            logger.log(MesType.NOTICE, "Init", "Program should be run 'as Administrator' to ensure all access rights to process memory and file objects.")
     else:
         if os.geteuid() == 0:
             isAdmin = True
-            logger.log("INFO", "Init", "Current user is root - very good")
+            logger.log(MesType.INFO, "Init", "Current user is root - very good")
         else:
-            logger.log("NOTICE", "Init", "Program should be run as 'root' to ensure all access rights to process memory and file objects.")
+            logger.log(MesType.NOTICE, "Init", "Program should be run as 'root' to ensure all access rights to process memory and file objects.")
 
     # Set process to nice priority ------------------------------------
     if os_platform == "windows":
@@ -1594,7 +1596,7 @@ if __name__ == '__main__':
         if isAdmin:
             loki.scan_processes(args.nopesieve, args.nolisten, args.excludeprocess, args.pesieveshellc)
         else:
-            logger.log("NOTICE", "Init", "Skipping process memory check. User has no admin rights.")
+            logger.log(MesType.NOTICE, "Init", "Skipping process memory check. User has no admin rights.")
 
     # Scan Path -------------------------------------------------------
     if not args.nofilescan:
@@ -1624,18 +1626,18 @@ if __name__ == '__main__':
            loki.scan_path(defaultPath)
 
     # Result ----------------------------------------------------------
-    logger.log("NOTICE", "Results", "Results: {0} alerts, {1} warnings, {2} notices".format(logger.alerts, logger.warnings, logger.notices))
+    logger.log(MesType.NOTICE, "Results", "Results: {0} alerts, {1} warnings, {2} notices".format(logger.alerts, logger.warnings, logger.notices))
     if logger.alerts:
-        logger.log("RESULT", "Results", "Indicators detected!")
-        logger.log("RESULT", "Results", "Loki recommends checking the elements on virustotal.com or Google and triage with a "
+        logger.log(MesType.RESULT, "Results", "Indicators detected!")
+        logger.log(MesType.RESULT, "Results", "Loki recommends checking the elements on virustotal.com or Google and triage with a "
                              "professional tool like THOR https://nextron-systems.com/thor in corporate networks.")
     elif logger.warnings:
-        logger.log("RESULT", "Results", "Suspicious objects detected!")
-        logger.log("RESULT", "Results", "Loki recommends a deeper analysis of the suspicious objects.")
+        logger.log(MesType.RESULT, "Results", "Suspicious objects detected!")
+        logger.log(MesType.RESULT, "Results", "Loki recommends a deeper analysis of the suspicious objects.")
     else:
-        logger.log("RESULT", "Results", "SYSTEM SEEMS TO BE CLEAN.")
+        logger.log(MesType.RESULT, "Results", "SYSTEM SEEMS TO BE CLEAN.")
 
-    logger.log("INFO", "Results", "Please report false positives via https://github.com/Neo23x0/signature-base")
-    logger.log("NOTICE", "Results", "Finished LOKI Scan SYSTEM: %s TIME: %s" % (getHostname(os_platform), getSyslogTimestamp()))
+    logger.log(MesType.INFO, "Results", "Please report false positives via https://github.com/Neo23x0/signature-base")
+    logger.log(MesType.NOTICE, "Results", "Finished LOKI Scan SYSTEM: %s TIME: %s" % (getHostname(os_platform), getSyslogTimestamp()))
 
 sys.exit(0)

--- a/plugins/loki-plugin-wmi.py
+++ b/plugins/loki-plugin-wmi.py
@@ -10,6 +10,8 @@ Author: @DidierStevens
 import hashlib
 import sys
 
+from utils.enums import MesType 
+
 def ScanWMI():
     global logger  # logger is defined in loki.py.__main__
 
@@ -18,7 +20,7 @@ def ScanWMI():
             import wmi
         except ImportError:
             wmi = None
-            logger.log("CRITICAL", "WMIScan", "Unable to import wmi")
+            logger.log(MesType.CRITICAL, "WMIScan", "Unable to import wmi")
             print("Unable to import wmi")
         oWMI = wmi.WMI(namespace=r'root\subscription')
 
@@ -31,43 +33,43 @@ def ScanWMI():
         try:
             leventFilter = oWMI.__eventFilter()
         except:
-            logger.log("WARNING", "WMIScan", 'Error retrieving __eventFilter')
+            logger.log(MesType.WARNING, "WMIScan", 'Error retrieving __eventFilter')
         try:
             lFilterToConsumerBinding = oWMI.__FilterToConsumerBinding()
         except:
-            logger.log("WARNING", "WMIScan", 'Error retrieving __FilterToConsumerBinding')
+            logger.log(MesType.WARNING, "WMIScan", 'Error retrieving __FilterToConsumerBinding')
         try:
             lCommandLineEventConsumer = oWMI.CommandLineEventConsumer()
         except:
-            logger.log("WARNING", "WMIScan", 'Error retrieving CommandLineEventConsumer')
+            logger.log(MesType.WARNING, "WMIScan", 'Error retrieving CommandLineEventConsumer')
         try:
             lActiveScriptEventConsumer = oWMI.ActiveScriptEventConsumer()
         except:
-            logger.log("WARNING", "WMIScan", 'Error retrieving ActiveScriptEventConsumer')
+            logger.log(MesType.WARNING, "WMIScan", 'Error retrieving ActiveScriptEventConsumer')
 
         for eventFilter in leventFilter:
             try:
                 hashEntry = hashlib.md5(str(eventFilter)).hexdigest()
                 if hashEntry not in knownHashes:
-                    logger.log("WARNING", "WMIScan", 'CLASS: __eventFilter MD5: %s NAME: %s QUERY: %s' % (hashEntry, eventFilter.wmi_property('Name').value, eventFilter.wmi_property('Query').value))
+                    logger.log(MesType.WARNING, "WMIScan", 'CLASS: __eventFilter MD5: %s NAME: %s QUERY: %s' % (hashEntry, eventFilter.wmi_property('Name').value, eventFilter.wmi_property('Query').value))
             except:
-                logger.log("INFO", "WMIScan", repr(str(eventFilter)))
+                logger.log(MesType.INFO, "WMIScan", repr(str(eventFilter)))
         for FilterToConsumerBinding in lFilterToConsumerBinding:
             try:
                 hashEntry = hashlib.md5(str(FilterToConsumerBinding)).hexdigest()
                 if hashEntry not in knownHashes:
-                    logger.log("WARNING", "WMIScan", 'CLASS: __FilterToConsumerBinding MD5: %s CONSUMER: %s FILTER: %s' % (hashEntry, FilterToConsumerBinding.wmi_property('Consumer').value, FilterToConsumerBinding.wmi_property('Filter').value))
+                    logger.log(MesType.WARNING, "WMIScan", 'CLASS: __FilterToConsumerBinding MD5: %s CONSUMER: %s FILTER: %s' % (hashEntry, FilterToConsumerBinding.wmi_property('Consumer').value, FilterToConsumerBinding.wmi_property('Filter').value))
             except:
-                logger.log("INFO", "WMIScan", repr(str(FilterToConsumerBinding)))
+                logger.log(MesType.INFO, "WMIScan", repr(str(FilterToConsumerBinding)))
         for CommandLineEventConsumer in lCommandLineEventConsumer:
             try:
                 hashEntry = hashlib.md5(str(CommandLineEventConsumer)).hexdigest()
                 if hashEntry not in knownHashes:
-                    logger.log("WARNING", "WMIScan", 'CLASS: CommandLineEventConsumer MD5: %s NAME: %s COMMANDLINETEMPLATE: %s' % (hashEntry, CommandLineEventConsumer.wmi_property('Name').value, CommandLineEventConsumer.wmi_property('CommandLineTemplate').value))
+                    logger.log(MesType.WARNING, "WMIScan", 'CLASS: CommandLineEventConsumer MD5: %s NAME: %s COMMANDLINETEMPLATE: %s' % (hashEntry, CommandLineEventConsumer.wmi_property('Name').value, CommandLineEventConsumer.wmi_property('CommandLineTemplate').value))
             except:
-                logger.log("INFO", "WMIScan", repr(str(CommandLineEventConsumer)))
+                logger.log(MesType.INFO, "WMIScan", repr(str(CommandLineEventConsumer)))
         for ActiveScriptEventConsumer in lActiveScriptEventConsumer:
-            logger.log("INFO", "WMIScan", repr(str(ActiveScriptEventConsumer)))
+            logger.log(MesType.INFO, "WMIScan", repr(str(ActiveScriptEventConsumer)))
 
 
 LokiRegisterPlugin("PluginWMI", ScanWMI, 1)  # noqa: F821 undefined name 'LokiRegisterPlugin'

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -12,6 +12,7 @@ class MesType(Enum):
 
     def __str__(self):
         return {
+            MesType.NOTICE: "NOTICE",
             MesType.INFO: "INFO",
             MesType.WARNING: "WARNING",
             MesType.ALERT: "ALERT",

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+class MesType(Enum):
+    NOTICE = 0
+    INFO = 1
+    WARNING = 2
+    ALERT = 3
+    DEBUG = 4
+    ERROR = 5
+    RESULT = 6
+    CRITICAL = 7
+
+    def __str__(self):
+        return {
+            MesType.INFO: "INFO",
+            MesType.WARNING: "WARNING",
+            MesType.ALERT: "ALERT",
+            MesType.DEBUG: "DEBUG",
+            MesType.ERROR: "ERROR",
+            MesType.RESULT: "RESULT",
+            MesType.CRITICAL: "CRITICAL"
+        }[self]


### PR DESCRIPTION
This pull request updates the logger to use an enum instead of the direct string literal comparison for determining the message type.

Tests all look fine although the performance gains aren't anything special, use or discard just thought I'd contribute as a THOR user. Happy holidays.