### PR TITLE
Show passed arguments in log-file

### DIFF
--- a/loki.py
+++ b/loki.py
@@ -1557,6 +1557,8 @@ if __name__ == '__main__':
     logger.log("NOTICE", "Init", "Starting Loki Scan VERSION: {3} SYSTEM: {0} TIME: {1} PLATFORM: {2}".format(
         getHostname(os_platform), getSyslogTimestamp(), getPlatformFull(), logger.version))
 
+    logger.log("NOTICE", "Init", "Passed arguments: {}".format(sys.argv))
+
     # Loki
     loki = Loki(args.intense)
 


### PR DESCRIPTION
Hi,
it has happened to me that others sent me log-files of scans and I was wondering with which passed arguments they executed loki.
Therefore I would like to request the addition of an additional log entry which contains the passed arguments.

Example of a passed log entry:
`[NOTICE] Passed arguments: ['loki.py', '--intense', '--noprocscan', '-p', 'C:\\Users\\Username\\Downloads\\temp', '--printall']`

Greetings
security-companion